### PR TITLE
Release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.0.1, 1.0.2, 1.0.3
+## 1.0.1, 1.0.2, 1.0.3, 1.0.4
 
 These releases include release engineering improvements, with no significant code or dependency changes.
 These are also the first releases since this project was donated to the `open-policy-agent` organization on Github.

--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,36 @@ plugins {
     id("checkstyle")
 }
 
+compileJava.options.encoding = "UTF-8"
+compileJava.options.compilerArgs += '-Xlint:unchecked'
+compileTestJava.options.encoding = "UTF-8"
+
+repositories {
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
+}
+
 java {
     sourceCompatibility = '17'
     targetCompatibility = '17'
 
     withSourcesJar()
     withJavadocJar()
+}
+
+model {
+    tasks.generatePomFileForMavenPublication {
+        destination = file("$buildDir/pom.xml")
+    }
+}
+
+jar {
+    dependsOn(":generatePomFileForMavenPublication")
+    archiveBaseName = "${artifactId}"
+
+    into("META-INF/maven/io.github.open-policy-agent/opa") {
+        from("$buildDir/pom.xml")
+    }
 }
 
 configurations {
@@ -29,10 +53,6 @@ tasks.named("bootJar") {
 
 tasks.named("jar") {
     archiveClassifier = ''
-}
-
-repositories {
-    mavenCentral()
 }
 
 javadoc {
@@ -101,6 +121,7 @@ test {
         //events "passed", "skipped", "failed", "standard_out", "standard_error"
     }
 }
+
 tasks.register("testModifiedSystemEnvProperties", Test) {
     useJUnitPlatform()
     group = "verification"
@@ -114,6 +135,7 @@ tasks.register("testModifiedSystemEnvProperties", Test) {
         environment.remove('OPA_PATH')
     }
 }
+
 test.finalizedBy(testModifiedSystemEnvProperties)
 
 gradle.projectsEvaluated {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 groupId=io.github.open-policy-agent.opa
 artifactId=springboot
-version=1.0.3
+version=1.0.4


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Yet another bugfix PR for the release workflows. This time, it's just the publish-to-Maven bits that are being adjusted.

### :chains: Related Resources

 - Previous releases in this chain:
   - #53
   - #54
   - #55