### PR TITLE
Release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.0.1, 1.0.2, 1.0.3, 1.0.4
+## 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5
 
 These releases include release engineering improvements, with no significant code or dependency changes.
 These are also the first releases since this project was donated to the `open-policy-agent` organization on Github.

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,9 @@ plugins {
     id("checkstyle")
 }
 
+version = "${version}"
+group = "${groupId}"
+
 compileJava.options.encoding = "UTF-8"
 compileJava.options.compilerArgs += '-Xlint:unchecked'
 compileTestJava.options.encoding = "UTF-8"
@@ -144,6 +147,14 @@ gradle.projectsEvaluated {
     }
 }
 
+sourcesJar {
+    archiveBaseName = "${artifactId}"
+}
+
+javadocJar {
+    archiveBaseName = "${artifactId}"
+}
+
 sonatypeCentralUpload {
     // This is your Sonatype generated username
     username = System.getenv("SONATYPE_USERNAME")
@@ -180,7 +191,7 @@ publishing {
                 description = 'A driver to connect Spring Boot applications to Open Policy Agent (OPA) and EOPA deployments'
                 url = 'https://github.com/open-policy-agent/opa-springboot'
                 scm {
-                    url = 'github.com/open-policy-agent/opa-springboot'
+                    url = 'https://github.com/open-policy-agent/opa-springboot'
                     connection = 'scm:git:ssh://git@github.com/open-policy-agent/opa-springboot.git'
                 }
                 licenses {
@@ -198,7 +209,7 @@ publishing {
                 }
                 organization {
                     name = 'Open Policy Agent'
-                    url = 'www.openpolicyagent.org'
+                    url = 'https://www.openpolicyagent.org'
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 groupId=io.github.open-policy-agent.opa
 artifactId=springboot
-version=1.0.4
+version=1.0.5


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Yet *another* bugfix PR for the release workflows. This time, it's just the publish-to-Maven bits that are being adjusted.

The previous attempt missed how OPA-Java's `build.gradle` was propagating the `groupId` property in, resulting in `pom.xml` having an empty element for the group ID.

### :chains: Related Resources

 - Previous releases in this chain:
   - #53
   - #54
   - #55
   - #56 